### PR TITLE
Add handling for reverse dns zones where appropriate

### DIFF
--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -17,7 +17,7 @@ define dhcp::pool (
   if member($parameters, 'ddns-updates on') {
       $o = split($network, '[.]')
       $reversezone = "${o[2]}.${o[1]}.${o[0]}.in-addr.arpa"
-      dhcp::ddns {
+      class { 'dhcp::ddns':
         zonemaster => hiera(dns_masters),
         key        => hiera(rndc_key),
         domains    => $reversezone,


### PR DESCRIPTION
If a dhcp zone has ddns turned on, then we need to add the correct ddns configuration for the reverse zone, otherwise attempts to update the reverse fail as the key is not defined. 
