### PR TITLE
Add UEFI Support

### DIFF
--- a/templates/dhcpd.conf-header.erb
+++ b/templates/dhcpd.conf-header.erb
@@ -18,4 +18,5 @@ option ntp-servers <%= @ntpservers.join(', ') %>;
 option fqdn.no-client-update on;  # set the "O" and "S" flag bits
 option fqdn.rcode2 255;
 option pxegrub code 150 = text;
+option architecture-type code 93 = unsigned integer 16;
 

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -24,7 +24,16 @@ subnet <%= @network %> netmask <%= @mask %> {
   }
 <% end -%>
 <% if @nextserver != '' and @pxefile != '' -%>
-  filename "<%= @pxefile %>";
+  class "pxeclients" {
+    match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";
+    if option architecture-type = 7 {
+      filename "syslinux.efi";
+    } elsif option architecture-type = 9 {
+      filename "syslinux.efi";
+    } else {
+      filename "pxelinux.0";
+    }
+  }
   next-server <%= @nextserver %>;
 <% end -%>
   option subnet-mask <%= @mask %>;


### PR DESCRIPTION
Creates a server class that should match all clients.  On machines with UEFI
support the architecture option should be set and EFI BC & EFI x86-64 machines
will pick up the EFI image, legacy systems should default to the old image.
